### PR TITLE
SPIR-V: Use ConstantComposite for Texture Offset Vector

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -1465,7 +1465,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                     }
 
                     var vectorType = context.TypeVector(context.TypeS32(), count);
-                    return context.CompositeConstruct(vectorType, elems);
+                    
+                    return context.ConstantComposite(vectorType, elems);
                 }
                 else
                 {


### PR DESCRIPTION
Fixes a bunch of freezes with SPIR-V on AMD hardware, and validation errors. Note: Obviously assumes input offsets are constant, which they currently are.